### PR TITLE
Disable mmalina for pr review

### DIFF
--- a/user-map.yaml
+++ b/user-map.yaml
@@ -19,10 +19,10 @@ users:
     slack_id: "jbieren"
     notify: false
     assign: true
-  mmalina:
-    slack_id: "mmalina"
-    notify: false
-    assign: true
+  # mmalina:
+  #   slack_id: "mmalina"
+  #   notify: false
+  #   assign: true
   seanconroy2021:
     slack_id: "sconroy"
     notify: false


### PR DESCRIPTION
Martin is on PTO, disabling PR review for him; it should be enabled once he is back