### PR TITLE
feat: add codecov integration for test coverage

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,6 +1,9 @@
 ---
-name: Python Checks for Pull Requests
+name: Python Checks
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened
@@ -29,8 +32,16 @@ jobs:
       - name: flake8 Lint
         if: steps.changed.outputs.any_changed == 'true'
         uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba  # v2.3.0
-      - name: Run pytest
+      - name: Run pytest with coverage
         if: steps.changed.outputs.any_changed == 'true'
         run: |
           python -m pip install -r jira-ci/requirements.txt
-          pytest
+          pytest --cov=jira_ci --cov-report=xml:coverage.xml jira-ci/
+      - name: Upload coverage to Codecov
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+flags:
+  unit-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/jira-ci/requirements.txt
+++ b/jira-ci/requirements.txt
@@ -1,3 +1,4 @@
 pytest>=8.4.2
+pytest-cov>=6.1.1
 requests>=2.32.5
 urllib3>=2.5.0


### PR DESCRIPTION
### Summary
- Add `pytest-cov` to `jira-ci/requirements.txt` and run tests with `--cov` to generate coverage reports
- Add `codecov/codecov-action` upload step to the Python CI workflow with `unit-tests` flag
- Add `push` trigger on `main` branch so Codecov has a baseline for accurate PR coverage diffs
- Add `codecov.yml` with flag configuration and carryforward enabled

### Setup required
Please add [`CODECOV_TOKEN`](https://app.codecov.io/gh/konflux-ci/release-service-automations/config/general) as a repository secret in GitHub Settings → Secrets → Actions