### PR TITLE
fix(RELEASE-2244): push to fork remote in promote-controller

### DIFF
--- a/promote-controller/scripts/promote-controller.sh
+++ b/promote-controller/scripts/promote-controller.sh
@@ -205,6 +205,7 @@ set_credentials "${FORK_OWNER}" "${FORK_OWNER_EMAIL}"
 echo "$SYNC_FORK_JSON"
 
 INFRA_REPO_URL="https://${FORK_OWNER}:${TOKEN}@github.com/${INFRA_OWNER}/${INFRA_REPO}.git"
+INFRA_FORK_URL="https://${FORK_OWNER}:${TOKEN}@github.com/${FORK_OWNER}/${INFRA_REPO}.git"
 PROMOTE_REPO_URL="https://${FORK_OWNER}:${TOKEN}@github.com/${PROMOTE_FORK_OWNER}/${PROMOTE_FORK_NAME}.git"
 
 # clone infra-deployments
@@ -212,6 +213,7 @@ git clone "$INFRA_REPO_URL"
 git clone "$PROMOTE_REPO_URL"
 
 cd ${INFRA_DIR}
+git remote add fork "$INFRA_FORK_URL"
 git fetch --all --tags --prune
 
 # Create a new branch
@@ -362,7 +364,7 @@ else
 fi
 
 git commit -m "$COMMIT_MESSAGE"
-git push origin "$NEW_BRANCH"
+git push fork "$NEW_BRANCH"
 
 # Create a pull request using GitHub API
 pr_creation_json=$(curl -s -X POST "https://api.github.com/repos/$INFRA_OWNER/$INFRA_REPO/pulls" \


### PR DESCRIPTION
The promote-controller script was cloning the upstream infra repo and pushing back to origin, which fails because release-service-bot does not have write access to the upstream repos.

This change adds the bot's fork as a separate git remote and pushes the promotion branch there instead. The PR creation already correctly references the fork via the "head" parameter, so only the push needed fixing.

Additionally, forks of redhat-appstudio/infra-deployments and redhat-appstudio/infra-common-deployments were created under the release-service-bot GitHub account, as they were missing.

Assisted-by: Cursor

Example of a successful workflow: https://github.com/konflux-ci/release-service-automations/actions/runs/25433792943/job/74606396015
Example of a created PR: https://github.com/redhat-appstudio/infra-deployments/pull/11601