### PR TITLE
feat(RELEASE-2405): add shared renovate presets for mintMaker

### DIFF
--- a/.github/workflows/check-renovate-config.yaml
+++ b/.github/workflows/check-renovate-config.yaml
@@ -1,0 +1,35 @@
+---
+name: Check Renovate Config
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.changed.outputs.all_changed_files }}
+      any_changed: ${{ steps.changed.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - name: Check for JSON changes
+        id: changed
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62  # v47
+        with:
+          files: |
+            mintMaker/**/*.json
+          matrix: true
+  validate:
+    needs: changes
+    if: needs.changes.outputs.any_changed == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: ${{ fromJson(needs.changes.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: konflux-ci/renovate-config-validator-action@adca50c2ce7ba1f3fab4d15f8783ad239f8090ae  # main
+        with:
+          config_file: ${{ matrix.config }}

--- a/mintMaker/README.md
+++ b/mintMaker/README.md
@@ -1,0 +1,38 @@
+# Renovate Presets
+
+Shared [Renovate config presets](https://docs.renovatebot.com/config-presets/) for Konflux Release Service repositories,
+used by [MintMaker](https://github.com/konflux-ci/mintmaker).
+
+## Presets
+
+| Preset  | File           | What it adds                                                         |
+|---------|----------------|----------------------------------------------------------------------|
+| default | `default.json` | `rebaseWhen`, tekton schedule and GitHub Actions with `pinDigests`   |
+| utils   | `utils.json`   | Extends default, weekly lock file maintenance and pep621 pinned deps |
+| catalog | `catalog.json` | Extends default, custom tekton paths and image filtering             |
+
+## Usage
+
+Base only:
+
+```
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/release-service-automations//mintMaker/default"]
+}
+```
+
+Base and catalog specific tekton paths and image filtering:
+
+```
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>konflux-ci/release-service-automations//mintMaker/catalog"]
+}
+```
+
+## Adding a preset
+
+1. Create `<name>.json` in the directory.
+2. Extend default if the new preset should include the base.
+3. Reference from repos as `github>konflux-ci/release-service-automations//mintMaker/<name>`

--- a/mintMaker/catalog.json
+++ b/mintMaker/catalog.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "release-service-catalog: base, custom tekton paths and image filtering",
+  "extends": ["github>konflux-ci/release-service-automations//mintMaker/default"],
+  "tekton": {
+    "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
+    "ignorePaths": [],
+    "includePaths": [
+      ".tekton/**",
+      "integration-tests/**",
+      "tasks/**",
+      "pipelines/**"
+    ],
+    "packageRules": [
+      {
+        "matchPackageNames": ["*"],
+        "enabled": false
+      },
+      {
+        "matchPackageNames": [
+          "quay.io/konflux-ci/release-service-utils",
+          "quay.io/conforma/cli"
+        ],
+        "enabled": true
+      }
+    ]
+  }
+}

--- a/mintMaker/default.json
+++ b/mintMaker/default.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "base: rebaseWhen, tekton schedule and GitHub Actions",
+  "rebaseWhen": "behind-base-branch",
+  "tekton": {
+    "schedule": ["* 0-4 * * *"]
+  },
+  "github-actions": {
+    "enabled": true,
+    "pinDigests": true
+  }
+}

--- a/mintMaker/utils.json
+++ b/mintMaker/utils.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "release-service-utils: base, lock file maintenance and pep621 pinning",
+  "extends": ["github>konflux-ci/release-service-automations//mintMaker/default"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Disable updates of pinned dependencies",
+      "matchManagers": ["pep621"],
+      "rangeStrategy": "in-range-only"
+    }
+  ]
+}


### PR DESCRIPTION
Center renovate config presets so each repo just extends one preset instead of duplicating configs. Includes base, utils and catalog presets.

Jira: https://redhat.atlassian.net/browse/RELEASE-2405
Assisted-by: Claude