### PR TITLE
Revert "fix: support made-by git footer in commits"

### DIFF
--- a/pr-ai-labeler/label_ai_pr.js
+++ b/pr-ai-labeler/label_ai_pr.js
@@ -13,7 +13,6 @@ const prNumber = process.env.PR_NUMBER;
 
 const ASSISTED_BY_RE = /assisted-by\s*:/i;
 const GENERATED_BY_RE = /generated-by\s*:/i;
-const MADE_BY_RE = /made-by\s*:/i;
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 2000;
@@ -107,13 +106,11 @@ async function removeLabel(label) {
     const msg = (c.commit && c.commit.message) || "";
     if (ASSISTED_BY_RE.test(msg)) needAiAssisted = true;
     if (GENERATED_BY_RE.test(msg)) needAiGenerated = true;
-    if (MADE_BY_RE.test(msg)) needMadeBy = true;
   }
 
   const labelsToAdd = [];
   if (needAiAssisted) labelsToAdd.push("ai-assisted");
   if (needAiGenerated) labelsToAdd.push("ai-generated");
-  if (needMadeBy) labelsToAdd.push("made-by-ai");
 
   let currentLabels;
   try {
@@ -126,7 +123,7 @@ async function removeLabel(label) {
   if (labelsToAdd.length === 0) {
     const toRemove = AI_LABELS.filter((l) => currentLabels.includes(l));
     if (toRemove.length === 0) {
-      console.log("No Assisted-By or Generated-By or Made-By found in PR commits. No AI labels to remove.");
+      console.log("No Assisted-By or Generated-By found in PR commits. No AI labels to remove.");
       return;
     }
     try {


### PR DESCRIPTION
Reverts konflux-ci/release-service-automations#15

Hit this error on another PR after merging this 

```
Run node label_ai_pr.js
/home/runner/work/release-service-utils/release-service-utils/.action-repo/pr-ai-labeler/label_ai_pr.js:116
  if (needMadeBy) labelsToAdd.push("made-by-ai");
  ^

ReferenceError: needMadeBy is not defined
    at /home/runner/work/release-service-utils/release-service-utils/.action-repo/pr-ai-labeler/label_ai_pr.js:116:3

Node.js v20.20.2
Error: Process completed with exit code 1.
```