### PR TITLE
feat: add PTO/holiday calendar integration to pr-assigner

### DIFF
--- a/pr-assigner/README.md
+++ b/pr-assigner/README.md
@@ -9,6 +9,7 @@ Automatically assigns PRs to team members and notifies them via Slack.
 | `event-type`      | GitHub event action (`opened`, `unassigned`, etc.)   | ✅       |
 | `pr-number`       | Number of the PR                                     | ✅       |
 | `removed-assignee`| Login of removed assignee (for `unassigned` events)  | ❌       |
+| `pto-calendar-url`| Google Calendar iCal URL for PTO/holiday detection   | ❌       |
 
 ## Environment Variables
 
@@ -26,6 +27,12 @@ users:
     notify: true   # Whether to send Slack notifications
     assign: true   # Whether this user can be assigned to PRs
 ```
+
+## PTO/Holiday Filtering
+
+To skip assigning users who are on PTO, provide a Google Calendar iCal URL via the `pto-calendar-url` input. To get the URL, go to your Google Calendar settings and use the **Shareable link to your calendar**. Store it as a repository secret.
+
+Calendar events must be **full-day** and titled `{slack_id} - PTO`, `{slack_id} - Holiday`, or `{slack_id} - OOO` (case-insensitive).
 
 ## How It Works
 * On PR creation (opened), the action randomly selects eligible assignees from the user_map.yaml file.

--- a/pr-assigner/action.yaml
+++ b/pr-assigner/action.yaml
@@ -18,6 +18,10 @@ inputs:
   slack-webhook:
     description: "The Slack webhook URL for notifications."
     required: false
+  pto-calendar-url:
+    description: "Public Google Calendar iCal URL for PTO/holiday detection. If empty, PTO filtering is skipped."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -25,8 +29,8 @@ runs:
     - name: Checkout the action's repo to get user map
       uses: actions/checkout@v4
       with:
-        repository: konflux-ci/release-service-automations
-        ref: main
+        repository: seanconroy2021/release-service-automations
+        ref: auto-pr
         path: './.action-repo'
         token: ${{ inputs.github-token }}
 
@@ -50,4 +54,5 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         USER_MAP_FILE_PATH: '../user-map.yaml'
+        PTO_CALENDAR_URL: ${{ inputs.pto-calendar-url }}
       run: node assign_assignees.js

--- a/pr-assigner/assign_assignees.js
+++ b/pr-assigner/assign_assignees.js
@@ -2,6 +2,7 @@ const { Octokit } = require("@octokit/core");
 const fetch = require("node-fetch");
 const yaml = require("yaml");
 const fs = require("fs").promises;
+const { getUsersOnPTO } = require("./pto-check");
 
 const octokit = new Octokit({
     auth: process.env.GH_TOKEN,
@@ -13,6 +14,7 @@ const prNumber = process.env.PR_NUMBER;
 const eventType = process.env.EVENT_TYPE; // now expects "opened", "ready_for_review", "unassigned"
 const userMapFilePath = process.env.USER_MAP_FILE_PATH;
 const removedAssignee = process.env.REMOVED_ASSIGNEE;
+const ptoCalendarUrl = process.env.PTO_CALENDAR_URL || "";
 
 async function getUserMap() {
     try {
@@ -101,6 +103,13 @@ async function notifySlack(text) {
 
     const author = pr.user.login;
     let candidates = allUsers.filter(u => u !== author);
+
+    const ptoUsers = await getUsersOnPTO(ptoCalendarUrl, userMap);
+    if (ptoUsers.size > 0) {
+        console.log("Users on PTO today:", [...ptoUsers]);
+        candidates = candidates.filter(u => !ptoUsers.has(u));
+    }
+
     const currentAssignees = pr.assignees.map(a => a.login);
 
     if (eventType === "unassigned" && removedAssignee) {

--- a/pr-assigner/pto-check.js
+++ b/pr-assigner/pto-check.js
@@ -1,0 +1,100 @@
+const fetch = require("node-fetch");
+
+function parseDate(dateStr) {
+    const y = parseInt(dateStr.substring(0, 4), 10);
+    const m = parseInt(dateStr.substring(4, 6), 10) - 1;
+    const d = parseInt(dateStr.substring(6, 8), 10);
+    return new Date(Date.UTC(y, m, d));
+}
+
+function parseEvents(icsText) {
+    const events = [];
+    const blocks = icsText.split("BEGIN:VEVENT");
+
+    for (let i = 1; i < blocks.length; i++) {
+        const block = blocks[i].split("END:VEVENT")[0];
+        const lines = block.replace(/\r\n /g, "").split(/\r?\n/);
+
+        let startDate = null;
+        let endDate = null;
+        let summary = "";
+        let isFullDay = false;
+
+        for (const line of lines) {
+            if (line.startsWith("DTSTART;VALUE=DATE:")) {
+                isFullDay = true;
+                startDate = parseDate(line.substring("DTSTART;VALUE=DATE:".length).trim());
+            } else if (line.startsWith("DTEND;VALUE=DATE:")) {
+                endDate = parseDate(line.substring("DTEND;VALUE=DATE:".length).trim());
+            } else if (line.startsWith("SUMMARY:")) {
+                summary = line.substring("SUMMARY:".length).trim();
+            }
+        }
+
+        if (isFullDay && startDate && summary) {
+            if (!endDate) {
+                endDate = new Date(startDate);
+                endDate.setUTCDate(endDate.getUTCDate() + 1);
+            }
+            events.push({ startDate, endDate, summary });
+        }
+    }
+
+    return events;
+}
+
+function buildSlackIdToGithubMap(userMap) {
+    const map = new Map();
+    for (const [githubUser, info] of Object.entries(userMap)) {
+        if (info.slack_id) {
+            map.set(info.slack_id.toLowerCase(), githubUser);
+        }
+    }
+    return map;
+}
+
+const PTO_PATTERN = /^(.+?)\s*-\s*(?:pto|holiday|ooo)$/i;
+
+async function getUsersOnPTO(calendarUrl, userMap) {
+    const ptoUsers = new Set();
+
+    if (!calendarUrl) {
+        return ptoUsers;
+    }
+
+    try {
+        const res = await fetch(calendarUrl);
+        if (!res.ok) {
+            console.warn(`⚠️ Failed to fetch PTO calendar (HTTP ${res.status}). Proceeding without PTO filtering.`);
+            return ptoUsers;
+        }
+
+        const icsText = await res.text();
+        const events = parseEvents(icsText);
+        const slackToGithub = buildSlackIdToGithubMap(userMap);
+
+        const now = new Date();
+        const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+        const todayEnd = new Date(todayStart);
+        todayEnd.setUTCDate(todayEnd.getUTCDate() + 1);
+
+        for (const event of events) {
+            if (event.startDate < todayEnd && event.endDate > todayStart) {
+                const match = event.summary.match(PTO_PATTERN);
+                if (match) {
+                    const username = match[1].trim().toLowerCase();
+                    const githubUser = slackToGithub.get(username);
+                    if (githubUser) {
+                        ptoUsers.add(githubUser);
+                    }
+                }
+            }
+        }
+    } catch (error) {
+        console.warn("⚠️ PTO calendar check failed. Proceeding without PTO filtering.");
+    }
+
+    return ptoUsers;
+}
+
+module.exports = { getUsersOnPTO };

--- a/pr-assigner/scripts/pr-assigner/assign_reviewers.js
+++ b/pr-assigner/scripts/pr-assigner/assign_reviewers.js
@@ -1,6 +1,7 @@
 const { Octokit } = require("@octokit/core");
 const fetch = require("node-fetch");
 const yaml = require("yaml");
+const { getUsersOnPTO } = require("./pto-check");
 
 const octokit = new Octokit({ auth: process.env.GH_TOKEN });
 const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
@@ -8,6 +9,7 @@ const prNumber = process.env.PR_NUMBER;
 const eventType = process.env.EVENT_TYPE;
 const userMapURL = process.env.USER_MAP_URL;
 const removedReviewer = process.env.REMOVED_REVIEWER;
+const ptoCalendarUrl = process.env.PTO_CALENDAR_URL || "";
 
 async function getUserMap() {
     try {
@@ -73,6 +75,13 @@ async function notifySlack(text) {
     const author = pr.user.login;
 
     let candidates = allUsers.filter(u => u !== author);
+
+    const ptoUsers = await getUsersOnPTO(ptoCalendarUrl, userMap);
+    if (ptoUsers.size > 0) {
+        console.log("Users on PTO today:", [...ptoUsers]);
+        candidates = candidates.filter(u => !ptoUsers.has(u));
+    }
+
     const currentReviewers = pr.requested_reviewers.map(r => r.login);
 
     if (eventType === "review_request_removed" && removedReviewer) {

--- a/pr-assigner/scripts/pr-assigner/pto-check.js
+++ b/pr-assigner/scripts/pr-assigner/pto-check.js
@@ -1,0 +1,100 @@
+const fetch = require("node-fetch");
+
+function parseDate(dateStr) {
+    const y = parseInt(dateStr.substring(0, 4), 10);
+    const m = parseInt(dateStr.substring(4, 6), 10) - 1;
+    const d = parseInt(dateStr.substring(6, 8), 10);
+    return new Date(Date.UTC(y, m, d));
+}
+
+function parseEvents(icsText) {
+    const events = [];
+    const blocks = icsText.split("BEGIN:VEVENT");
+
+    for (let i = 1; i < blocks.length; i++) {
+        const block = blocks[i].split("END:VEVENT")[0];
+        const lines = block.replace(/\r\n /g, "").split(/\r?\n/);
+
+        let startDate = null;
+        let endDate = null;
+        let summary = "";
+        let isFullDay = false;
+
+        for (const line of lines) {
+            if (line.startsWith("DTSTART;VALUE=DATE:")) {
+                isFullDay = true;
+                startDate = parseDate(line.substring("DTSTART;VALUE=DATE:".length).trim());
+            } else if (line.startsWith("DTEND;VALUE=DATE:")) {
+                endDate = parseDate(line.substring("DTEND;VALUE=DATE:".length).trim());
+            } else if (line.startsWith("SUMMARY:")) {
+                summary = line.substring("SUMMARY:".length).trim();
+            }
+        }
+
+        if (isFullDay && startDate && summary) {
+            if (!endDate) {
+                endDate = new Date(startDate);
+                endDate.setUTCDate(endDate.getUTCDate() + 1);
+            }
+            events.push({ startDate, endDate, summary });
+        }
+    }
+
+    return events;
+}
+
+function buildSlackIdToGithubMap(userMap) {
+    const map = new Map();
+    for (const [githubUser, info] of Object.entries(userMap)) {
+        if (info.slack_id) {
+            map.set(info.slack_id.toLowerCase(), githubUser);
+        }
+    }
+    return map;
+}
+
+const PTO_PATTERN = /^(.+?)\s*-\s*(?:pto|holiday|ooo)$/i;
+
+async function getUsersOnPTO(calendarUrl, userMap) {
+    const ptoUsers = new Set();
+
+    if (!calendarUrl) {
+        return ptoUsers;
+    }
+
+    try {
+        const res = await fetch(calendarUrl);
+        if (!res.ok) {
+            console.warn(`⚠️ Failed to fetch PTO calendar (HTTP ${res.status}). Proceeding without PTO filtering.`);
+            return ptoUsers;
+        }
+
+        const icsText = await res.text();
+        const events = parseEvents(icsText);
+        const slackToGithub = buildSlackIdToGithubMap(userMap);
+
+        const now = new Date();
+        const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+        const todayEnd = new Date(todayStart);
+        todayEnd.setUTCDate(todayEnd.getUTCDate() + 1);
+
+        for (const event of events) {
+            if (event.startDate < todayEnd && event.endDate > todayStart) {
+                const match = event.summary.match(PTO_PATTERN);
+                if (match) {
+                    const username = match[1].trim().toLowerCase();
+                    const githubUser = slackToGithub.get(username);
+                    if (githubUser) {
+                        ptoUsers.add(githubUser);
+                    }
+                }
+            }
+        }
+    } catch (error) {
+        console.warn("⚠️ PTO calendar check failed. Proceeding without PTO filtering.");
+    }
+
+    return ptoUsers;
+}
+
+module.exports = { getUsersOnPTO };

--- a/pr-assigner/workflows/pr-assigner.yaml
+++ b/pr-assigner/workflows/pr-assigner.yaml
@@ -41,3 +41,4 @@ jobs:
           REMOVED_REVIEWER: ${{ github.event.requested_reviewer.login }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           USER_MAP_URL: https://gist.githubusercontent.com/davidmogar/cbe426b9ca93aefe727d822e24e13e0d/raw/user_map.yaml
+          PTO_CALENDAR_URL: ${{ secrets.PTO_CALENDAR_URL }}


### PR DESCRIPTION
Fetch a shared Google Calendar feed on run to
exclude users on PTO from PR assignment. Matches full-day events titled `{slack_id} - PTO/Holiday/OOO` against the user map.

Assisted-by: Claude