### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/pr-ai-labeler/action.yaml
+++ b/pr-ai-labeler/action.yaml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the action's repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
       with:
         repository: konflux-ci/release-service-automations
         ref: main
@@ -24,7 +24,7 @@ runs:
         token: ${{ inputs.github-token }}
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: '20'
 

--- a/pr-ai-labeler/workflows/pr-ai-labeler.yaml
+++ b/pr-ai-labeler/workflows/pr-ai-labeler.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '18'
 

--- a/pr-assigner/action.yaml
+++ b/pr-assigner/action.yaml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the action's repo to get user map
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
       with:
         repository: konflux-ci/release-service-automations
         ref: main
@@ -31,7 +31,7 @@ runs:
         token: ${{ inputs.github-token }}
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: '20'
 

--- a/pr-assigner/workflows/pr-assigner.yaml
+++ b/pr-assigner/workflows/pr-assigner.yaml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '18'
           cache: 'npm'


### PR DESCRIPTION
Prevent supply chain attacks by replacing mutable tags with pinned commit SHAs in all workflow files.

Generated-by: Claude